### PR TITLE
Fix Semi-Transparent sprite blending

### DIFF
--- a/src/gba_drawer_merge.vhd
+++ b/src/gba_drawer_merge.vhd
@@ -363,8 +363,6 @@ begin
    -- ####################################
    process (clk100)
       variable special_effect_var : unsigned(1 downto 0);
-      variable prio1              : unsigned(1 downto 0);
-      variable prio2              : unsigned(1 downto 0);
       variable secondpixel        : std_logic_vector(14 downto 0);
    begin
       if rising_edge(clk100) then
@@ -382,32 +380,14 @@ begin
          -- special effect control
          special_effect_var   := special_effect_in;
          special_out_cycle4   <= '0';
-      
-         if ((special_enable_cycle3 = '1' and special_effect_in > 0) or pixeldata_obj_cycle3(OBJALPHA) = '1') then
+
+         if (special_enable_cycle3 = '1' and special_effect_in > 0) then
       
             if (firstprio_cycle3 /= "000000") then
             
-               if (pixeldata_obj_cycle3(OBJALPHA) = '1' and firstprio_cycle3(4 downto 0) = "10000") then
-                  special_effect_var := "01";
-               end if;
-            
-               if (special_effect_var = "01") then
-                  
-                  prio1 := "00";
-                  if    (firstprio_cycle3(OBJ) = '1') then prio1 := unsigned(pixeldata_obj_cycle3(OBJPRIOH downto OBJPRIOL));
-                  elsif (firstprio_cycle3(BG0) = '1') then prio1 := Prio_BG0;
-                  elsif (firstprio_cycle3(BG1) = '1') then prio1 := Prio_BG1;
-                  elsif (firstprio_cycle3(BG2) = '1') then prio1 := Prio_BG2;
-                  elsif (firstprio_cycle3(BG3) = '1') then prio1 := Prio_BG3; end if;                      
-               
-                  prio2 := "00";
-                  if    (secondprio_cycle3(OBJ) = '1') then prio2 := unsigned(pixeldata_obj_cycle3(OBJPRIOH downto OBJPRIOL));
-                  elsif (secondprio_cycle3(BG0) = '1') then prio2 := Prio_BG0;
-                  elsif (secondprio_cycle3(BG1) = '1') then prio2 := Prio_BG1;
-                  elsif (secondprio_cycle3(BG2) = '1') then prio2 := Prio_BG2;
-                  elsif (secondprio_cycle3(BG3) = '1') then prio2 := Prio_BG3; end if;                  
-               
-                  if (secondprio_cycle3 /= "000000" and prio2 >= prio1) then
+               if (special_effect_in = "01") then
+
+                  if (secondprio_cycle3 /= "000000") then
                      special_out_cycle4  <= '1';
                   end if;
                
@@ -422,6 +402,11 @@ begin
             
          end if;
          
+         if (pixeldata_obj_cycle3(OBJALPHA) = '1' and firstprio_cycle3(4 downto 0) = "10000" and secondprio_cycle3 /= "000000") then
+            special_effect_var := "01";
+            special_out_cycle4 <= '1';
+         end if;
+
          special_effect_cycle4 <= special_effect_var;
       
          -- special effect data


### PR DESCRIPTION
Force blending only when top pixel is sprite and overlaps a second
target pixel so that other effects like brighten are applied to the
non-overlapping pixels.

The priority checking when blending is enabled is removed because it
seems redundant.

Fixes:
- Mario & Donkey Kong save file fading border and full screen fading
- Street Fighter Alpha 3 options green highlight
- Yoshi's Island language/save file icon full screen fading
- Tonc bld_demo mode 2/3 should darken or brighten the sprite on the
left on the non-overlapping pixels. Tested on real GBA hardware.