### PR TITLE
Added GPIO quirk to games that have rumble ROM hack

### DIFF
--- a/GBA.sv
+++ b/GBA.sv
@@ -677,6 +677,9 @@ always @(posedge clk_sys) begin
 			if(cart_id[31:8] == "BKA" ) begin gpio_quirk <= 1;                                             end // Sennen Kazoku
 			if(cart_id[31:8] == "BR4" ) begin gpio_quirk <= 1;                                             end // Rockman EXE 4.5
 			if(cart_id[31:8] == "V49" ) begin gpio_quirk <= 1;                                             end // Drill Dozer
+			if(cart_id[31:8] == "A88" ) begin gpio_quirk <= 1;                                             end // Mario & Luigi: Superstar Saga (Cartridge Rumble Patch)
+			if(cart_id[31:8] == "BPP" ) begin gpio_quirk <= 1;                                             end // Pokemon Pinball: Ruby & Sapphire (Cartridge Rumble Patch)
+			if(cart_id[31:8] == "AX4" ) begin gpio_quirk <= 1;                                             end // Super Mario Advance 4: Super Mario Bros. 3 (Cartridge Rumble Patch)
 			if(cart_id[31:8] == "BHG" ) begin                                           sprite_quirk <= 1; end // Gunstar Super Heroes
 			if(cart_id[31:8] == "BGX" ) begin                                           sprite_quirk <= 1; end // Gunstar Super Heroes
 			if(cart_id[31:8] == "KHP" ) begin tilt_quirk <= 1;                                             end // Koro Koro Puzzle JP


### PR DESCRIPTION
These games officially support rumble through the Game Boy Player (GameCube peripheral). The rom hacks in question enable and translate the Game Boy Player rumble signals to cartridge rumble signals. This also allows them to be picked up by MiSTer, but only by default when gpio_quirk is set.

Mario & Luigi: Superstar Saga (Cartridge Rumble Patch)
https://www.romhacking.net/hacks/6065/

Pokémon Pinball: Ruby & Sapphire (Cartridge Rumble Patch)
https://www.romhacking.net/hacks/6256/

Super Mario Advance 4: Super Mario Bros. 3 (Cartridge Rumble Patch)
https://www.romhacking.net/hacks/6234/